### PR TITLE
fix: add logging for when no api key is specified; update version numbers to match actual version

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,4 +1,4 @@
-VERSION = '3.2.0'
+VERSION = '3.2.1'
 
 API_BASE_URL = 'https://www.piracybound.com/api'
 API_KEY_PREFIX = 'manilua_'

--- a/backend/main.py
+++ b/backend/main.py
@@ -50,6 +50,8 @@ class Plugin:
         if self.has_api_key() and isinstance(self._api_key, str) and self._api_key.strip() != "":
             self.api_manager.set_api_key(self._api_key)
             self.manilua_manager.set_api_key(self._api_key)
+        else:
+            logger.log("manilua: backend initialized without API key")
 
     def _load_api_key(self):
         api_key_file = os.path.join(self.backend_path, 'api_key.txt')
@@ -96,8 +98,10 @@ class Plugin:
         logger.log("manilua: v3.2.0 ready")
 
     def _load(self):
+        logger.log(f"manilua: backend loading (v{VERSION})")
         self._inject_webkit_files()
         Millennium.ready()
+        logger.log("manilua: backend ready")
 
     def _unload(self):
         logger.log("Unloading manilua plugin")

--- a/backend/main.py
+++ b/backend/main.py
@@ -95,7 +95,7 @@ class Plugin:
             logger.error(f'manilua: Failed to inject: {e}')
 
     def _front_end_loaded(self):
-        logger.log("manilua: v3.2.0 ready")
+        logger.log("manilua: v3.2.1 ready")
 
     def _load(self):
         logger.log(f"manilua: backend loading (v{VERSION})")

--- a/backend/main.py
+++ b/backend/main.py
@@ -95,7 +95,7 @@ class Plugin:
             logger.error(f'manilua: Failed to inject: {e}')
 
     def _front_end_loaded(self):
-        logger.log("manilua: v3.2.1 ready")
+        logger.log(f"manilua: v{VERSION} ready")
 
     def _load(self):
         logger.log(f"manilua: backend loading (v{VERSION})")

--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,6 @@
   "name": "manilua",
   "common_name": "manilua",
   "description": "download games easily.",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "author": "debounced / piracybound"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,6 @@
   "name": "manilua",
   "common_name": "manilua",
   "description": "download games easily.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": "debounced / piracybound"
 }


### PR DESCRIPTION
Adds logging for when no API key is specified.
Fixes errors and broken Millennium menu.

Also increments version numbers to 3.2.1